### PR TITLE
Provide functions to create pseudo-random source

### DIFF
--- a/random/doc.go
+++ b/random/doc.go
@@ -1,0 +1,6 @@
+// Package random provides functionality to generate pseudo-random test data.
+//
+// All random numbers and data are created deterministically using a
+// pseudo-random number generator. This generator's output is determined by the
+// value a seed that us set using the current time, or set explicitly.
+package random

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -140,3 +140,30 @@ func TestSequence(t *testing.T) {
 	t.Log("last seq num: ", lastNum)
 	require.Equal(t, secondNum+(seqCount*seqSize)+1, lastNum, "expected lastnum to be %d + %d + 1, was %d", secondNum, seqCount*seqSize, lastNum)
 }
+
+func TestNewRand(t *testing.T) {
+	rng1 := random.NewSeededRand(137)
+	rng2 := random.NewSeededRand(137)
+	allEqual := true
+	for i := 0; i < 100; i++ {
+		n1 := rng1.Int()
+		n2 := rng2.Int()
+		if n1 != n2 {
+			allEqual = false
+			break
+		}
+	}
+	require.True(t, allEqual)
+
+	rng1 = random.NewRand()
+	rng2 = random.NewRand()
+	for i := 0; i < 100; i++ {
+		n1 := rng1.Int()
+		n2 := rng2.Int()
+		if n1 != n2 {
+			allEqual = false
+			break
+		}
+	}
+	require.False(t, allEqual)
+}


### PR DESCRIPTION
For some test applications it is necesssary to have a source of pseudo-random data.

A new pseudo-random source can be created with a seed that is:
- The next value from a global sequence, or
- A value that is explicitly provided