### PR TITLE
refactor: Make go-multiaddr v0.15 forward compatible change

### DIFF
--- a/random/random.go
+++ b/random/random.go
@@ -138,15 +138,13 @@ func Multiaddrs(n int) []multiaddr.Multiaddr {
 	return maddrs
 }
 
+var httpMultiaddrComponent = multiaddr.StringCast("/http")
+
 // HttpMultiaddrs returns a slice of n random unique Multiaddrs.
 func HttpMultiaddrs(n int) []multiaddr.Multiaddr {
 	maddrs := Multiaddrs(n)
-	scheme, err := multiaddr.NewComponent("http", "")
-	if err != nil {
-		panic(err)
-	}
 	for i, ma := range maddrs {
-		maddrs[i] = multiaddr.Join(ma, scheme)
+		maddrs[i] = multiaddr.Join(ma, httpMultiaddrComponent)
 	}
 	return maddrs
 }


### PR DESCRIPTION
Changes this library to be forward compatible with the next go-multiaddr v0.15 release. This will make the go-multiaddr release a bit easier.

The tests in this PR test against go-multiaddr v0.14 and the tests here https://github.com/ipfs/go-test/pull/10 test against v0.15. 