### PR TITLE
fix: multihash random generation

### DIFF
--- a/random/random.go
+++ b/random/random.go
@@ -88,16 +88,10 @@ func Bytes(n int) []byte {
 // Cids returns a slice of n random unique CIDs.
 func Cids(n int) []cid.Cid {
 	cids := make([]cid.Cid, 0, n)
-	set := make(map[[32]byte]struct{})
 	rng := NewRand()
 	for len(cids) < n {
 		var b [32]byte
 		rng.Read(b[:])
-		if _, ok := set[b]; ok {
-			continue
-		}
-		set[b] = struct{}{}
-
 		h, err := multihash.Encode(b[:], multihash.SHA2_256)
 		if err != nil {
 			panic(err)
@@ -149,15 +143,9 @@ func HttpMultiaddrs(n int) []multiaddr.Multiaddr {
 func Multihashes(n int) []multihash.Multihash {
 	rng := NewRand()
 	mhashes := make([]multihash.Multihash, 0, n)
-	set := make(map[[32]byte]struct{})
 	for len(mhashes) < n {
 		var b [32]byte
 		rng.Read(b[:])
-		if _, ok := set[b]; ok {
-			continue
-		}
-		set[b] = struct{}{}
-
 		h, err := multihash.Encode(b[:], multihash.SHA2_256)
 		if err != nil {
 			panic(err.Error())

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -115,7 +115,7 @@ func TestSequence(t *testing.T) {
 	var ready sync.WaitGroup
 	ready.Add(seqCount)
 
-	for i := 0; i < seqCount; i++ {
+	for range seqCount {
 		go func() {
 			ready.Done()
 			<-startGate
@@ -127,7 +127,7 @@ func TestSequence(t *testing.T) {
 	ready.Wait()
 	close(startGate)
 
-	for i := 0; i < seqCount; i++ {
+	for range seqCount {
 		seq := <-seqs
 		for _, num := range seq {
 			_, found := seen[num]
@@ -145,7 +145,7 @@ func TestNewRand(t *testing.T) {
 	rng1 := random.NewSeededRand(137)
 	rng2 := random.NewSeededRand(137)
 	allEqual := true
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		n1 := rng1.Int()
 		n2 := rng2.Int()
 		if n1 != n2 {
@@ -157,7 +157,7 @@ func TestNewRand(t *testing.T) {
 
 	rng1 = random.NewRand()
 	rng2 = random.NewRand()
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		n1 := rng1.Int()
 		n2 := rng2.Int()
 		if n1 != n2 {


### PR DESCRIPTION
## Problem

Random multihash and cid generation currently hashes a random buffer whose size is proportional to the number of desired items.

When I try to generate 100'000 random multihashes, the operation takes forever.

Hashing a random buffer (of size >= 32 bytes) with SHA2-256 is equivalent to using a random 32 bytes buffer as the hash digest directly, at least when generating random multihashes and cids for tests. The latter uses less resources.

## Fix

I updated to code to generate random multihashes and cids without needing to compute hash digests at all. The resulting multihashes and cids are just as random as the previously generated ones.

Also, no items were ever added to the `set` to deduplicate the cids/multihashes (probably useless anyway since it is HARD to find collision on 256-bits). I fixed it, but it should also be fine to remove it (as long as we trust the source of randomness).